### PR TITLE
Fix : deploy_component_version.py

### DIFF
--- a/deploy_component_version.py
+++ b/deploy_component_version.py
@@ -43,7 +43,7 @@ def get_deployment_components(name):
     components = []
 
     for deployment in response['deployments']:
-        if deployment['deploymentName'] == name:
+        if deploymentName in deployment and deployment['deploymentName'] == name:
 
             try:
                 response = greengrassv2_client.get_deployment(deploymentId=deployment['deploymentId'])


### PR DESCRIPTION
Check if `deploymentName` is present in deployment item's list

*Issue #, if available:*

*Description of changes:*
You are not forced to have a name for deployment. If the name is not present, expected item `deploymentName` is not present. If it's the case, this stops the search process.  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
